### PR TITLE
Clean dots from translated keywords

### DIFF
--- a/lib/unlocalize/localized_date_time_parser.rb
+++ b/lib/unlocalize/localized_date_time_parser.rb
@@ -60,7 +60,7 @@ module Unlocalize
         # TODO Make it a bulk lookup again at some point in the future when the bug is fixed in i18n.
         translated = [:month_names, :abbr_month_names, :day_names, :abbr_day_names].map do |key|
           I18n.t(key, :scope => :date)
-        end.flatten.compact
+        end.flatten.compact.map { |str| str.chomp('.') }
 
         original = (Date::MONTHNAMES + Date::ABBR_MONTHNAMES + Date::DAYNAMES + Date::ABBR_DAYNAMES).compact
         translated.each_with_index { |name, i| datetime.gsub!(/\b#{name}\b/i, original[i]) }


### PR DESCRIPTION
So, this fixes a couple of issues for the Frenchies, namely:
1. The regexp replacement was failing for some abbreviated month names, say "juil.' (July) , because they contained a dot and because `\b` (word-boundary) looks back to see if the previous character is a word character, which is never the case in `juil.` - we fix this by chomping dots before comparing
2. The way the code was done, we would run the replacement multiple times, indeed, we would also replace stuff that we replaced before as you can see from the comically true example: 
   1. "5 mar. 2014" (FR)
   2. finds "mar" and replaces with the English equivalent , which is "Mar"
   3. keeps look and finds "Mar" , which is the abbreviated version of "Mardi" and replaces with the English equivalent "Tuesday" (abbreviated to Tue)
   4. ?????
   5. "5 Tue 2014" - JOB WELL DONE! GOES HOME

This in theory fixes everything, I've added these cases to the Homestay.com specs as this is a pretty bare library :P
